### PR TITLE
Removed intermediary dirs, selectable compression algorithms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM mongo:4
 
-RUN apt-get update && apt-get -y install awscli lsb-release curl
+RUN apt-get update && apt-get -y install awscli lsb-release curl xz-utils zstd
 
 RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -c -s) main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Run the container with the following arguments `restore $TIMESTAMP $COLLECTIONS`
 |AWS_SECRET_ACCESS_KEY|the aws secret key|[x] (AWS only)|
 |AWS_REGION|the aws region|[x] (AWS only)|
 |GOOGLE_CREDENTIALS_PATH|location of the service account JSON file|[x] GCP only|
+|COMPRESSION|compression algorithm to use, default `gzip`, other options are `xz` and `zstd`||
 
 ***Note***
 in addition to the `GOOGLE_CREDENTIALS_PATH` env var you will need to mount the credentials file into the container

--- a/run.sh
+++ b/run.sh
@@ -54,22 +54,40 @@ fi
 function doBackup {
 
     TIMESTAMP=`date +%Y-%m-%dT%H-%M-%S`
-    BACKUP_NAME="$TIMESTAMP.tar.gz"
+    BACKUP_NAME="$TIMESTAMP.tar"
     BUCKET_PATH="$BUCKET_PREFIX://$BUCKET/$BACKUP_NAME"
 
+    local algo=`echo $COMPRESSION | awk '{print tolower($0)}'`
+    case $algo in
+        gzip)
+            BACKUP_NAME="${BACKUP_NAME}.gz"
+            ;;
+        xz)
+            BACKUP_NAME="${BACKUP_NAME}.xz"
+            algo="${algo} -zT0"
+            ;;
+        zstd)
+            BACKUP_NAME="${BACKUP_NAME}.zst"
+            algo="zstd -zT0"
+            ;;
+        *)
+            BACKUP_NAME="${BACKUP_NAME}.gz"
+            algo="gzip"
+            ;;
+    esac
+
+    echo "algo is: ${algo}"
+
     ##
-    # Create our mongo dump into a timestamped directory
+    # Create a mongo dump to STDOUT, tar-ing & compressing. This allows us to save on intermidary pvc space.
     #
-    mongodump --uri ${MONGO} -o ${TIMESTAMP}
+    mongodump --uri ${MONGO} --archive | tar -cf - | eval $algo - > ${BACKUP_NAME}
 
     if [[ $? -ne 0 ]];then
      echo "Failed to create mongo dump!"
         exit 1
     fi
 
-    ## package up the lot into a tar.gz
-    tar -zcvf ${BACKUP_NAME} ${TIMESTAMP}
-    rm -rf ${TIMESTAMP}
     ##
     # Move the backup to S3 or exit
     #
@@ -90,16 +108,38 @@ function doBackup {
 
 
 function doRestore {
-    BACKUP_NAME="${TIMESTAMP}.tar.gz"
+    BACKUP_NAME="${TIMESTAMP}.tar"
     BUCKET_PATH="$BUCKET_PREFIX://$BUCKET/$BACKUP_NAME"
     mkdir -p restore
+
+    local algo=`echo $COMPRESSION | awk '{print tolower($0)}'`
+    case $algo in
+        gzip)
+            BACKUP_NAME="${BACKUP_NAME}.gz"
+            algo="gzip -cd"
+            ;;
+        xz)
+            BACKUP_NAME="${BACKUP_NAME}.xz"
+            alg="${algo} -cd"
+            ;;
+        zstd)
+            BACKUP_NAME="${BACKUP_NAME}.zst"
+            algo="${algo} -cd"
+            ;;
+        *)
+            BACKUP_NAME="${BACKUP_NAME}.gz"
+            algo="gzip -cd"
+            ;;
+    esac
 
     $UTIL cp ${BUCKET_PATH} ${BACKUP_NAME}
     if [[ $? -ne 0 ]];then
      echo "Failed to copy mongo dump from bucket ${BUCKET_PATH}"
         exit 1
     fi
-    tar -xzvf ${BACKUP_NAME}
+
+    # Decompress to stdout | untar
+    eval $algo | tar -xf - 
     rm ${BACKUP_NAME}
 
     for i in $(echo ${COLLECTIONS} | sed "s/,/ /g")


### PR DESCRIPTION
This commit introduces the possibility of selecting between gzip, xz and
zstd compression. If no option is specified gzip will be used as default
for backwards compatibility.

Backups and restores no longer need to create an intermediary directory
prior to archiving and compressing; on backup this is done all in one.
On restore an intermediary dir is still needed.