### PR TITLE
Legacy restore, fixed compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ if you have large collections it is advised you mount a PVC to the following dir
 Run the container in your environment (typically on a cron) with the configured environment variables
 
 ### Restore
-Run the container with the following arguments `restore $TIMESTAMP $COLLECTIONS`
+Run the container with the following arguments `restore $TIMESTAMP $COLLECTIONS`. If you are restoring backups made prior to mongo-burs v1.4.0 use `legacyRestore` instead of _restore_; this is due to previous versions creating an archive of a mongo dump directory, rather than compressing an archive binary blob. Both commands take the same `$TIMESTAMP` and `$COLLECTIONS` args.
 
 |Argument|Format|Description|
 |--------|------|-----------|

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Run the container with the following arguments `restore $TIMESTAMP $COLLECTIONS`
 |Argument|Format|Description|
 |--------|------|-----------|
 |TIMESTAMP|YYYY-MM-DDTHH-MM-SS (2019-01-01T12:42:04)|the date to restore the database from|
-|COLLECTIONS|DB/Collection,... (test/test,test/test2)|the collections you wish to restore into the database| 
+|COLLECTIONS|Collection,... (test/test,test/test2)|the collections you wish to restore into the database as a CSV string| 
 
 
 ### Environment Variables

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Run the container with the following arguments `restore $TIMESTAMP $COLLECTIONS`
 |Argument|Format|Description|
 |--------|------|-----------|
 |TIMESTAMP|YYYY-MM-DDTHH-MM-SS (2019-01-01T12:42:04)|the date to restore the database from|
-|COLLECTIONS|Collection,... (test/test,test/test2)|the collections you wish to restore into the database as a CSV string| 
+|COLLECTIONS|Database.Collection,... (test.test,test.test2)|the collections you wish to restore into the database as a CSV string|
 
 
 ### Environment Variables


### PR DESCRIPTION
Using `--archive` produces a binary blob, there is thus no need for tar. This commit drops tar-ing before compression and fixes restoring from a backup, restoring from multiple collections is supported by parsing the same archive multiple times (to avoid exposing `nsInclude`/`nsExclude` semantics.

Added an additional restore option `legacyRestore` to handle backups made by taring & compressing a dump directory, rather than a binary blob.